### PR TITLE
Add order button ios

### DIFF
--- a/src/MobileApp/XamarinCRM.UITest/Pages/ABSFilamentPage.cs
+++ b/src/MobileApp/XamarinCRM.UITest/Pages/ABSFilamentPage.cs
@@ -6,7 +6,7 @@ namespace XamarinCRM.UITest
     public class ABSFilamentPage : BasePage
     {
         public ABSFilamentPage(IApp app, Platform platform)
-            : base(app, platform, "FIL-ABS-VLT", "ABS Filament")
+            : base(app, platform, "FIL-ABS-BLU", "ABS Filament")
         {
         }
 

--- a/src/MobileApp/XamarinCRM.UITest/Pages/CustomerOrderDetailsPage.cs
+++ b/src/MobileApp/XamarinCRM.UITest/Pages/CustomerOrderDetailsPage.cs
@@ -25,9 +25,9 @@ namespace XamarinCRM.UITest
             }
             if (OniOS)
             {
-                ProductField = x => x.Class("UITextField").Descendant(0);
-                PriceField = x => x.Class("UITextField").Descendant(1);
-                DateField = x => x.Class("UITextField").Descendant(2);
+                ProductField = x => x.Class("UITextField").Index(0);
+                PriceField = x => x.Class("UITextField").Index(1);
+                DateField = x => x.Class("UITextField").Index(2);
                 SaveButton = x => x.Id("save.png");
             }
         }

--- a/src/MobileApp/XamarinCRM.UITest/Pages/CustomerOrderDetailsPage.cs
+++ b/src/MobileApp/XamarinCRM.UITest/Pages/CustomerOrderDetailsPage.cs
@@ -25,9 +25,9 @@ namespace XamarinCRM.UITest
             }
             if (OniOS)
             {
-                ProductField = x => x.Class("UITextFieldLabel").Descendant(0);
-                PriceField = x => x.Class("UITextFieldLabel").Descendant(1);
-                DateField = x => x.Class("UITextFieldLabel").Descendant(2);
+                ProductField = x => x.Class("UITextField").Descendant(0);
+                PriceField = x => x.Class("UITextField").Descendant(1);
+                DateField = x => x.Class("UITextField").Descendant(2);
                 SaveButton = x => x.Id("save.png");
             }
         }

--- a/src/MobileApp/XamarinCRM.UITest/Pages/CustomerOrdersPage.cs
+++ b/src/MobileApp/XamarinCRM.UITest/Pages/CustomerOrdersPage.cs
@@ -21,7 +21,7 @@ namespace XamarinCRM.UITest
             if (OniOS)
             {
                 SecondOrder = x => x.Class("UITableViewCellContentView").Index(1);
-                NewOrderButton = x => x.Marked("add");
+                NewOrderButton = x => x.Marked("add_ios_gray");
             }
         }
 

--- a/src/MobileApp/XamarinCRM.UITest/Pages/LeadContactPage.cs
+++ b/src/MobileApp/XamarinCRM.UITest/Pages/LeadContactPage.cs
@@ -61,7 +61,10 @@ namespace XamarinCRM.UITest
 
         public void GoToLeadDetails()
         {
-            app.Tap(DetailsTab);
+            if (OnAndroid)
+                app.ScrollUpTo("Company");
+            if (OniOS)
+                app.Tap(DetailsTab);
         }
 
         public LeadContactPage EnterLeadContact(

--- a/src/MobileApp/XamarinCRM.UITest/Pages/LeadDetailsPage.cs
+++ b/src/MobileApp/XamarinCRM.UITest/Pages/LeadDetailsPage.cs
@@ -70,7 +70,12 @@ namespace XamarinCRM.UITest
 
         public void GoToLeadContact()
         {
-            app.Tap(ContactTab);
+            if (OnAndroid)
+            {
+                app.ScrollDownTo("Phone");
+            }
+            if (OniOS)
+                app.Tap(ContactTab);
         }
 
         public LeadDetailsPage EnterLeadDetails(

--- a/src/MobileApp/XamarinCRM.UITest/Pages/PLAFilamentPage.cs
+++ b/src/MobileApp/XamarinCRM.UITest/Pages/PLAFilamentPage.cs
@@ -5,7 +5,7 @@ namespace XamarinCRM.UITest
     public class PLAFilamentPage : BasePage
     {
         public PLAFilamentPage(IApp app, Platform platform)
-            : base(app, platform, "FIL-PLA-VLT", "PLA Filament")
+            : base(app, platform, "FIL-PLA-BLU", "PLA Filament")
         {
         }
 

--- a/src/MobileApp/XamarinCRM.UITest/Pages/ProductDetailsPage.cs
+++ b/src/MobileApp/XamarinCRM.UITest/Pages/ProductDetailsPage.cs
@@ -5,11 +5,15 @@ namespace XamarinCRM.UITest
 {
     public class ProductDetailsPage : BasePage
     {
-        readonly Query AddToOrderButton = x => x.Marked("ADD TO ORDER");
+        readonly Query AddToOrderButton;
 
         public ProductDetailsPage(IApp app, Platform platform)
             : base(app, platform, "content", "Back")
         {
+            if (OnAndroid)
+            {
+                AddToOrderButton = x => x.Marked("Add to Order").Parent(0).Sibling();
+            }
             if (OniOS)
             {
                 AddToOrderButton = x => x.Id("add_ios_blue");

--- a/src/MobileApp/XamarinCRM.UITest/Tests/AbstractSetup.cs
+++ b/src/MobileApp/XamarinCRM.UITest/Tests/AbstractSetup.cs
@@ -53,7 +53,7 @@ namespace XamarinCRM.UITest
 //
             app.Screenshot("On Home Page");
         }
-
+            
         void LogIn()
         {
             var deviceIndex = Environment.GetEnvironmentVariable("XTC_DEVICE_INDEX");

--- a/src/MobileApp/XamarinCRM.UITest/Tests/CustomersTest.cs
+++ b/src/MobileApp/XamarinCRM.UITest/Tests/CustomersTest.cs
@@ -10,6 +10,7 @@ namespace XamarinCRM.UITest
         {
         }
 
+        [Category("TestLogin")]
         [Test]
         public void CheckCustomerDetails()
         {

--- a/src/MobileApp/XamarinCRM.UITest/Tests/OrdersTest.cs
+++ b/src/MobileApp/XamarinCRM.UITest/Tests/OrdersTest.cs
@@ -39,7 +39,7 @@ namespace XamarinCRM.UITest
 
             new ProductDetailsPage(app, platform)
                 .AddToOrder();
-
+            
             new CustomerOrderDetailsPage(app, platform)
                 .ChangePrice(44)
                 .SaveAndExit();

--- a/src/MobileApp/XamarinCRM.UITest/Tests/OrdersTest.cs
+++ b/src/MobileApp/XamarinCRM.UITest/Tests/OrdersTest.cs
@@ -60,7 +60,7 @@ namespace XamarinCRM.UITest
 
             new CustomerOrdersPage(app, platform) 
                 .AddNewOrder();
-
+            
             new CustomerOrderDetailsPage(app, platform)
                 .ChangeProduct();
 

--- a/src/MobileApp/XamarinCRM.UITest/Tests/OrdersTest.cs
+++ b/src/MobileApp/XamarinCRM.UITest/Tests/OrdersTest.cs
@@ -108,17 +108,6 @@ namespace XamarinCRM.UITest
         {
             AddNewOrder();
 
-//            if (platform == Platform.Android)
-//            {
-//                new CustomersPage(app, platform)
-//                    .ClickFirstContact();
-//            }
-            if (platform == Platform.iOS)
-            {
-                new CustomerContactPage(app, platform)
-                    .NavigateToCustomerOrders();
-            }
-
             new CustomerOrdersPage(app, platform) 
                 .SelectFirstOrder();
 

--- a/src/MobileApp/XamarinCRM.UITest/Tests/OrdersTest.cs
+++ b/src/MobileApp/XamarinCRM.UITest/Tests/OrdersTest.cs
@@ -35,7 +35,7 @@ namespace XamarinCRM.UITest
                 .SelectPart("ABS Filament");
 
             new ABSFilamentPage(app, platform)
-                .SelectColor("VLT");
+                .SelectColor("BLU-LIGHT");
 
             new ProductDetailsPage(app, platform)
                 .AddToOrder();
@@ -108,13 +108,16 @@ namespace XamarinCRM.UITest
         {
             AddNewOrder();
 
-            if (platform == Platform.Android)
+//            if (platform == Platform.Android)
+//            {
+//                new CustomersPage(app, platform)
+//                    .ClickFirstContact();
+//            }
+            if (platform == Platform.iOS)
             {
-                new CustomersPage(app, platform)
-                    .ClickFirstContact();
+                new CustomerContactPage(app, platform)
+                    .NavigateToCustomerOrders();
             }
-            new CustomerContactPage(app, platform)
-                .NavigateToCustomerOrders();
 
             new CustomerOrdersPage(app, platform) 
                 .SelectFirstOrder();

--- a/src/MobileApp/XamarinCRM/Pages/Customers/CustomerOrdersPage.xaml.cs
+++ b/src/MobileApp/XamarinCRM/Pages/Customers/CustomerOrdersPage.xaml.cs
@@ -95,24 +95,9 @@ namespace XamarinCRM.Pages.Customers
             ToolbarItem newOrderButton = new ToolbarItem();
             newOrderButton.Text = "Add";
             newOrderButton.Icon = "add_ios_gray";
-            newOrderButton.Clicked += NewOrderButton_Clicked;
+            newOrderButton.Clicked += (o, ea) => AddNewOrderButtonClicked(o, ea);
             return newOrderButton;
         }
-
-        async void NewOrderButton_Clicked (object sender, EventArgs e)
-        {
-            NavigationPage.SetBackButtonTitle(this, "Back");
-
-            await Navigation.PushAsync(
-                new CustomerOrderDetailPage()
-                {
-                    BindingContext = new OrderDetailViewModel(ViewModel.Account)
-                        { 
-                            Navigation = ViewModel.Navigation 
-                        }
-                });
-        }
-
     }
 
     /// <summary>

--- a/src/MobileApp/XamarinCRM/Pages/Customers/CustomerOrdersPage.xaml.cs
+++ b/src/MobileApp/XamarinCRM/Pages/Customers/CustomerOrdersPage.xaml.cs
@@ -39,7 +39,6 @@ namespace XamarinCRM.Pages.Customers
             if (Device.OS == TargetPlatform.iOS)
             {
                 SetToolBarItems();
-//                ToolbarItems.Add(new ToolbarItem("Add", "add_ios_gray", AddNewOrderClicked));
             }
         }
 

--- a/src/MobileApp/XamarinCRM/Pages/Customers/CustomerOrdersPage.xaml.cs
+++ b/src/MobileApp/XamarinCRM/Pages/Customers/CustomerOrdersPage.xaml.cs
@@ -35,6 +35,12 @@ namespace XamarinCRM.Pages.Customers
             InitializeComponent();
 
             AddNewOrderButton.Clicked = AddNewOrderButtonClicked;
+
+            if (Device.OS == TargetPlatform.iOS)
+            {
+                SetToolBarItems();
+//                ToolbarItems.Add(new ToolbarItem("Add", "add_ios_gray", AddNewOrderClicked));
+            }
         }
 
         protected override void OnAppearing()
@@ -77,6 +83,37 @@ namespace XamarinCRM.Pages.Customers
                     });
             }
         }
+
+        void SetToolBarItems()
+        {
+            ToolbarItems.Clear();
+
+            ToolbarItems.Add(GetNewOrderToolBarItem());
+        }
+
+        ToolbarItem GetNewOrderToolBarItem()
+        {
+            ToolbarItem newOrderButton = new ToolbarItem();
+            newOrderButton.Text = "Add";
+            newOrderButton.Icon = "add_ios_gray";
+            newOrderButton.Clicked += NewOrderButton_Clicked;
+            return newOrderButton;
+        }
+
+        async void NewOrderButton_Clicked (object sender, EventArgs e)
+        {
+            NavigationPage.SetBackButtonTitle(this, "Back");
+
+            await Navigation.PushAsync(
+                new CustomerOrderDetailPage()
+                {
+                    BindingContext = new OrderDetailViewModel(ViewModel.Account)
+                        { 
+                            Navigation = ViewModel.Navigation 
+                        }
+                });
+        }
+
     }
 
     /// <summary>

--- a/src/MobileApp/XamarinCRM/Pages/Customers/CustomerOrdersPage.xaml.cs
+++ b/src/MobileApp/XamarinCRM/Pages/Customers/CustomerOrdersPage.xaml.cs
@@ -95,7 +95,7 @@ namespace XamarinCRM.Pages.Customers
             ToolbarItem newOrderButton = new ToolbarItem();
             newOrderButton.Text = "Add";
             newOrderButton.Icon = "add_ios_gray";
-            newOrderButton.Clicked += (o, ea) => AddNewOrderButtonClicked(o, ea);
+            newOrderButton.Clicked += (o, ea) => AddNewOrderButtonClicked.Invoke(o, ea);
             return newOrderButton;
         }
     }

--- a/src/MobileApp/XamarinCRM/Services/AuthenticationService.cs
+++ b/src/MobileApp/XamarinCRM/Services/AuthenticationService.cs
@@ -69,19 +69,21 @@ namespace XamarinCRM.Services
 
             // query the Azure Graph API for some detailed user information about the logged in user
             var userFetcher = activeDirectoryGraphApiClient.Me.ToUser();
-            var user = await userFetcher.ExecuteAsync();
 
-            // record some info about the logged in user with Xamarin Insights
-            Insights.Identify(
-                _AuthenticationResult.UserInfo.UniqueId, 
-                new Dictionary<string, string> 
-                {
-                    { Insights.Traits.Email, user.UserPrincipalName },
-                    { Insights.Traits.FirstName, user.GivenName },
-                    { Insights.Traits.LastName, user.Surname },
-                    { "Preferred Language", user.PreferredLanguage }
-                }
-            );
+            await Task.Factory.StartNew(async () => {
+                var user = await userFetcher.ExecuteAsync();
+                // record some info about the logged in user with Xamarin Insights
+                Insights.Identify(
+                    _AuthenticationResult.UserInfo.UniqueId, 
+                    new Dictionary<string, string> 
+                    {
+                        { Insights.Traits.Email, user.UserPrincipalName },
+                        { Insights.Traits.FirstName, user.GivenName },
+                        { Insights.Traits.LastName, user.Surname },
+                        { "Preferred Language", user.PreferredLanguage }
+                    }
+                );
+            });
 
             return true;
         }

--- a/src/MobileApp/XamarinCRM/Services/AuthenticationService.cs
+++ b/src/MobileApp/XamarinCRM/Services/AuthenticationService.cs
@@ -68,8 +68,6 @@ namespace XamarinCRM.Services
             );
 
             // query the Azure Graph API for some detailed user information about the logged in user
-//            var userFetcher = activeDirectoryGraphApiClient.Me.ToUser();
-
             Task.Run(async () => {
                 var user = activeDirectoryGraphApiClient.Me.ExecuteAsync().Result;
                 // record some info about the logged in user with Xamarin Insights

--- a/src/MobileApp/XamarinCRM/Services/AuthenticationService.cs
+++ b/src/MobileApp/XamarinCRM/Services/AuthenticationService.cs
@@ -68,10 +68,10 @@ namespace XamarinCRM.Services
             );
 
             // query the Azure Graph API for some detailed user information about the logged in user
-            var userFetcher = activeDirectoryGraphApiClient.Me.ToUser();
+//            var userFetcher = activeDirectoryGraphApiClient.Me.ToUser();
 
-            await Task.Factory.StartNew(async () => {
-                var user = await userFetcher.ExecuteAsync();
+            Task.Run(async () => {
+                var user = activeDirectoryGraphApiClient.Me.ExecuteAsync().Result;
                 // record some info about the logged in user with Xamarin Insights
                 Insights.Identify(
                     _AuthenticationResult.UserInfo.UniqueId, 


### PR DESCRIPTION
This PR fixes #97. I modeled the implementation of this button off of the `add` button that is visible on the sales dashboard page.

Here are test cloud runs that demonstrate the fix is working:
iOS: https://testcloud.xamarin.com/test/xamarin-crm_fd39804e-7be9-444c-946e-abc12e4264e0/
Android: https://testcloud.xamarin.com/test/xamarin-crm_2e07c73c-bdde-4931-8432-a67e081f8c30/

Note: this PR also contains fixes to the Test Suite.