### PR TITLE
Awaiting the inner task instead of outer task

### DIFF
--- a/src/MobileApp/XamarinCRM/Services/AuthenticationService.cs
+++ b/src/MobileApp/XamarinCRM/Services/AuthenticationService.cs
@@ -63,7 +63,7 @@ namespace XamarinCRM.Services
                         throw new Exception("Failed to DeAuthenticate!");
                     }
                     _AuthenticationResult = null;
-                });
+                }).Unwrap();
             return true;
         }
 


### PR DESCRIPTION
Task.Factory.StartNew returns a nested task (Task<Task>). Awaiting a nested task is dangerous:

If DeAuthenticate() call returns false, an exception in line 63 will be thrown to the inner task. The exceptions in a task can only propagate to the caller if the task is awaited or waited. In line 58, only the outer task is awaited so the exceptions in the inner task will be swallowed and have no effect at all: the user will never see the “DeAuthenticate” error and the developer cannot handle this exception.


That's why, we should always unwrap the nested task (with Unwrap() or using Task.Run) and await the inner task.