### PR TITLE
Fix no longer supported ABI

### DIFF
--- a/src/MobileApp/XamarinCRM.Android/XamarinCRM.Android.csproj
+++ b/src/MobileApp/XamarinCRM.Android/XamarinCRM.Android.csproj
@@ -17,7 +17,7 @@
     <AndroidManifest>Properties\AndroidManifest.xml</AndroidManifest>
     <NuGetPackageImportStamp>
     </NuGetPackageImportStamp>
-    <AndroidSupportedAbis>armeabi;armeabi-v7a;x86</AndroidSupportedAbis>
+    <AndroidSupportedAbis>armeabi-v7a;x86;x86_64;arm64-v8a</AndroidSupportedAbis>
     <MandroidI18n />
     <JavaMaximumHeapSize>1G</JavaMaximumHeapSize>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>


### PR DESCRIPTION
armeabi is no longer supported and throws a compile error on latest VS 16.3 as seen in issue #126. Fixing this and also adding 64-bit support (which is now required for all Google Play apps).

Fixes #126.